### PR TITLE
Making Sport Metacello compatible

### DIFF
--- a/src/.filetree
+++ b/src/.filetree
@@ -1,3 +1,1 @@
-{"Metadata" : "false",
-"packageExtension" : ".package",
-"propertyFileExtension" : ".json" }
+{"packageExtension" : ".package"}

--- a/src/BaselineOfSport.package/BaselineOfSport.class/instance/baseline..st
+++ b/src/BaselineOfSport.package/BaselineOfSport.class/instance/baseline..st
@@ -2,7 +2,7 @@ baselines
 baseline: spec
   <baseline>
   spec
-    for: #(#'gemstone' #'gemstone64')
+    for: #'gemstone'
     do: [ 
       spec
         package: 'Sport' with: [ spec file: 'Sport.v3' ];

--- a/src/BaselineOfSport.package/BaselineOfSport.class/instance/baseline..st
+++ b/src/BaselineOfSport.package/BaselineOfSport.class/instance/baseline..st
@@ -5,5 +5,5 @@ baseline: spec
     for: #'gemstone'
     do: [ 
       spec
-        package: 'Sport' with: [ spec file: 'Sport.v3' ];
+        package: 'Sport';
         yourself ]

--- a/src/BaselineOfSport.package/BaselineOfSport.class/instance/projectClass.st
+++ b/src/BaselineOfSport.package/BaselineOfSport.class/instance/projectClass.st
@@ -1,3 +1,4 @@
 accessing
 projectClass
-    ^ MetacelloCypressBaselineProject
+  Smalltalk at: #'MetacelloCypressBaselineProject' ifPresent: [ :cl | ^ cl ].
+  ^ super projectClass

--- a/src/BaselineOfSport.package/monticello.meta/version
+++ b/src/BaselineOfSport.package/monticello.meta/version
@@ -1,0 +1,1 @@
+(name 'BaselineOfSport-jupiter.33' message 'initial version' id 'f3eee16b-401f-44b2-9b67-33d9ed8ad14d' date '06/24/2025' time '12:17:16' author 'jupiter' ancestors () stepChildren ())


### PR DESCRIPTION
Since we are updating Sport library as part of [Glass1 repository](https://github.com/glassdb/glass/pull/45).  We need to update the library mirror itself.